### PR TITLE
Update Sun.cfg

### DIFF
--- a/build/GameData/InterstellarConsortium/Configs/Sun.cfg
+++ b/build/GameData/InterstellarConsortium/Configs/Sun.cfg
@@ -16,3 +16,47 @@
         }
     }
 }
+@Kopernicus:FOR[InterstellarConsortium]
+{
+	@Body:HAS[#identifier[Squad/Sun]]
+	{
+		@ScaledVersion
+		{
+			Light
+			{
+				sunAU = 261600000
+				brightnessCurve
+                {
+                    key = 0.0000000005 0.03 0 0
+					key = 0.00000005 0.04 0 0
+                    key = 0.0001 0.1 0 0
+                    key = 0.001 0.3 0 0
+                    key = 0.01 0.4 0 0
+                    key = 0.1 4 0 0
+                    key = 0.2 6 0 0
+                    key = 0.3 10 0 0
+					key = 0.5 22 0 0
+					key = 0.65 0 0 0
+                }
+				IntensityCurve
+				{
+					key = 0 1 0 0
+					key = 6.044e9 0.9 0 0
+					key = 2e+12 0 0 0
+				}
+				IVAIntensityCurve
+				{
+					key = 0 1 0 0
+					key = 6.044e9 0.9 0 0
+					key = 2e+12 0 0 0
+				}
+				ScaledIntensityCurve
+				{
+					key = 0 1 0 0
+					key = 1007333.33333 0.9 0 0
+					key = 333333333.333 0 0 0
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Reduces the sun's light beyond Eeloo's orbit. The lighting should be nearly identical to stock, before slowly dimming at the edge of the Sun's SOI. Change brightnessCurve to dim sunlight to a point.

These changes are necessary for all stars in the Interstellar Consortium, or all stars would be shining and everything would be too bright. IC-plugin should set a good example for the bare minimum.